### PR TITLE
Enable incremental builds to keep node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 This repository contains the source for building Angular applications based on
 the official httpd24 CentOS and Red Hat images using source-to-image (S2I).
+This image supports incremental builds by reusing the `node_modules` folder
+between builds. To use this, you must enable incremental builds in your build
+configuration.
 
 For more information about using these images with OpenShift, please see the
 official OpenShift documentation.
@@ -20,6 +23,9 @@ The following configuration environment variables are specific to this image:
     untrusted CA, you'll need to mount the certificate of the untrusted CA in
     the build container, and use the `npm_config_cafile` environment variable
     to point to the mounted CA certificate.
+* **DISCARD_NODE_MODULES** - set to `true` to discard the `node_modules`
+    directory containing node.js dependencies for smaller container images.
+    Otherwise the directory will be retained to allow for incremental builds.
 
 All other environment variables from the base image can also be overriden.
 

--- a/s2i/bin/assemble
+++ b/s2i/bin/assemble
@@ -17,6 +17,11 @@ echo "---> Running the httpd-24 assemble script..."
 /usr/libexec/s2i/assemble-httpd
 echo "---> Done running the httpd-24 assemble script"
 
+if [ "$(ls /tmp/artifacts/ 2>/dev/null)" ]; then
+  echo "---> Restoring build artifacts (node_modules)"
+  mv /tmp/artifacts/node_modules ./
+fi
+
 if [ "$(ls /tmp/ng-environments/ 2>/dev/null)" ]; then
   echo "---> Copying custom Angular environment files"
   cp -pf /tmp/ng-environments/* ./src/environments/
@@ -37,7 +42,11 @@ scl enable rh-nodejs8 'npm install --only=dev'
 echo "---> Building and installing the Angular application with the '$NG_CONFIG' configuration"
 scl enable rh-nodejs8 "./node_modules/@angular/cli/bin/ng build --configuration=$NG_CONFIG --output-path dist"
 # Delete all source files since they are no longer needed
-find -maxdepth 1 -not -name "dist" -not -name "." -exec rm -rf {} \;
+find -maxdepth 1 -not -name "dist" -not -name "." -not -name "node_modules" -exec rm -rf {} \;
+# Delete node_modules if the user has elected to do so
+if [ "$DISCARD_NODE_MODULES" = true ]; then
+  rm -rf node_modules
+fi
 # Move the build files to the source root
 mv dist/* .
 # Remove the now empty dist directory

--- a/s2i/bin/save-artifacts
+++ b/s2i/bin/save-artifacts
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+#
+# S2I save-artifacts script for the 's2i-angular-httpd24' image.
+# The save-artifacts script streams a tar archive to standard output.
+# The archive contains the files and folders you want to re-use in the next build.
+#
+# For more information see the documentation:
+#	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
+#
+
+pushd ${HOME} >/dev/null
+if [ -d node_modules ]; then
+    # Add the deps to a tar stream
+    tar cf - node_modules
+fi
+popd >/dev/null

--- a/test/run
+++ b/test/run
@@ -55,7 +55,7 @@ container_port() {
 }
 
 run_s2i_build() {
-  s2i build ${s2i_args} file://${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+  s2i build ${s2i_args} --incremental=true file://${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
 }
 
 prepare() {
@@ -156,4 +156,3 @@ test_connection
 check_result $?
 
 cleanup
-


### PR DESCRIPTION
I've tried making some slight changes to allow keeping `node_modules` for incremental builds.

I'm not recommending we merge this yet; I've been trying to test this in OpenShift but incremental builds always hang on the preliminary step of pulling the latest container image from the associated docker registry. I've got a build running right now that, according to the logs, has been pulling the image for twenty minutes. I'm a little stumped by it and wanted to open a PR in case there's anything glaringly wrong with it.